### PR TITLE
[FEAT] 랭킹 조회 및 보상 지급 구현

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
 
 	// JWT 관련 라이브러리
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/demo/src/main/java/BodyBuddy/demo/DemoApplication.java
+++ b/demo/src/main/java/BodyBuddy/demo/DemoApplication.java
@@ -2,8 +2,10 @@ package BodyBuddy.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DemoApplication {
 
 	public static void main(String[] args) {

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/controller/RankingController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/controller/RankingController.java
@@ -1,0 +1,64 @@
+package BodyBuddy.demo.domain.avatar.controller;
+
+import BodyBuddy.demo.domain.avatar.dto.RankingResponse;
+import BodyBuddy.demo.domain.avatar.dto.RankingResponse.GlobalRanking;
+import BodyBuddy.demo.domain.avatar.dto.RankingResponse.UpdateResponse;
+import BodyBuddy.demo.domain.avatar.service.RankingService;
+import BodyBuddy.demo.domain.avatar.service.RankingUpdateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/rankings")
+@RequiredArgsConstructor
+@Tag(name = "Ranking API", description = "랭킹 관련 API")
+public class RankingController {
+
+    private final RankingService rankingService;
+    private final RankingUpdateService rankingUpdateService;
+
+    @GetMapping("/global")
+    @Operation(summary = "글로벌 랭킹 조회", description = "전체 글로벌 랭킹을 조회합니다. 최대 55명까지 반환됩니다.")
+    public ResponseEntity<Page<GlobalRanking>> getGlobalRankings(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "55") int size) {
+        return ResponseEntity.ok(rankingService.getGlobalRankings(page, size));
+    }
+
+    @GetMapping("/gym/{gymId}")
+    @Operation(summary = "GYM 랭킹 조회", description = "특정 GYM의 전체 랭킹을 조회합니다. 최대 55명까지 반환됩니다.")
+    public ResponseEntity<Page<RankingResponse.GlobalRanking>> getGymRankings(
+        @PathVariable Long gymId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "55") int size) {
+        return ResponseEntity.ok(rankingService.getGymRankings(gymId, page, size));
+    }
+
+    @GetMapping("/user/{memberId}")
+    @Operation(summary = "회원 글로벌 순위 조회", description = "특정 회원의 글로벌 순위를 조회합니다.")
+    public ResponseEntity<RankingResponse.GlobalRanking> getUserGlobalRanking(@PathVariable Long memberId) {
+        return ResponseEntity.ok(rankingService.getUserGlobalRanking(memberId));
+    }
+
+    @GetMapping("/user/{memberId}/gym/{gymId}")
+    @Operation(summary = "회원 체육관 순위 조회", description = "특정 회원의 체육관 내 순위를 조회합니다.")
+    public ResponseEntity<RankingResponse.GlobalRanking> getUserGymRanking(@PathVariable Long memberId, @PathVariable Long gymId) {
+        return ResponseEntity.ok(rankingService.getUserGymRanking(memberId, gymId));
+    }
+
+    @PostMapping("/update")
+    @Operation(summary = "랭킹 업데이트", description = "모든 사용자의 랭킹 점수에 따라 포인트와 경험치를 업데이트합니다.")
+    public ResponseEntity<List<UpdateResponse>> updateRankings() {
+        return ResponseEntity.ok(rankingUpdateService.updateRankings());
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/controller/RankingController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/controller/RankingController.java
@@ -5,12 +5,14 @@ import BodyBuddy.demo.domain.avatar.dto.RankingResponse.GlobalRanking;
 import BodyBuddy.demo.domain.avatar.dto.RankingResponse.UpdateResponse;
 import BodyBuddy.demo.domain.avatar.service.RankingService;
 import BodyBuddy.demo.domain.avatar.service.RankingUpdateService;
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.ResponseEntity;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,36 +31,56 @@ public class RankingController {
 
     @GetMapping("/global")
     @Operation(summary = "글로벌 랭킹 조회", description = "전체 글로벌 랭킹을 조회합니다. 최대 55명까지 반환됩니다.")
-    public ResponseEntity<Page<GlobalRanking>> getGlobalRankings(
+    public ApiResponse<PagedModel<GlobalRanking>> getGlobalRankings(
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "55") int size) {
-        return ResponseEntity.ok(rankingService.getGlobalRankings(page, size));
+        Page<GlobalRanking> rankings = rankingService.getGlobalRankings(page, size);
+        PagedModel<GlobalRanking> pagedModel = PagedModel.of(
+            rankings.getContent(),
+            new PagedModel.PageMetadata(
+                rankings.getSize(),
+                rankings.getNumber(),
+                rankings.getTotalElements(),
+                rankings.getTotalPages()
+            )
+        );
+        return ApiResponse.of(SuccessStatus.RANKINGSUCCESS, pagedModel);
     }
 
     @GetMapping("/gym/{gymId}")
     @Operation(summary = "GYM 랭킹 조회", description = "특정 GYM의 전체 랭킹을 조회합니다. 최대 55명까지 반환됩니다.")
-    public ResponseEntity<Page<RankingResponse.GlobalRanking>> getGymRankings(
+    public ApiResponse<PagedModel<GlobalRanking>> getGymRankings(
         @PathVariable Long gymId,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "55") int size) {
-        return ResponseEntity.ok(rankingService.getGymRankings(gymId, page, size));
+        Page<RankingResponse.GlobalRanking> rankings = rankingService.getGymRankings(gymId, page, size);
+        PagedModel<RankingResponse.GlobalRanking> pagedModel = PagedModel.of(
+            rankings.getContent(),
+            new PagedModel.PageMetadata(
+                rankings.getSize(),
+                rankings.getNumber(),
+                rankings.getTotalElements(),
+                rankings.getTotalPages()
+            )
+        );
+        return ApiResponse.of(SuccessStatus.RANKINGSUCCESS, pagedModel);
     }
 
     @GetMapping("/user/{memberId}")
     @Operation(summary = "회원 글로벌 순위 조회", description = "특정 회원의 글로벌 순위를 조회합니다.")
-    public ResponseEntity<RankingResponse.GlobalRanking> getUserGlobalRanking(@PathVariable Long memberId) {
-        return ResponseEntity.ok(rankingService.getUserGlobalRanking(memberId));
+    public ApiResponse<RankingResponse.GlobalRanking> getUserGlobalRanking(@PathVariable Long memberId) {
+        return ApiResponse.of(SuccessStatus.RANKINGSUCCESS, rankingService.getUserGlobalRanking(memberId));
     }
 
     @GetMapping("/user/{memberId}/gym/{gymId}")
     @Operation(summary = "회원 체육관 순위 조회", description = "특정 회원의 체육관 내 순위를 조회합니다.")
-    public ResponseEntity<RankingResponse.GlobalRanking> getUserGymRanking(@PathVariable Long memberId, @PathVariable Long gymId) {
-        return ResponseEntity.ok(rankingService.getUserGymRanking(memberId, gymId));
+    public ApiResponse<RankingResponse.GlobalRanking> getUserGymRanking(@PathVariable Long memberId, @PathVariable Long gymId) {
+        return ApiResponse.of(SuccessStatus.RANKINGSUCCESS, rankingService.getUserGymRanking(memberId, gymId));
     }
 
     @PostMapping("/update")
     @Operation(summary = "랭킹 업데이트", description = "모든 사용자의 랭킹 점수에 따라 포인트와 경험치를 업데이트합니다.")
-    public ResponseEntity<List<UpdateResponse>> updateRankings() {
-        return ResponseEntity.ok(rankingUpdateService.updateRankings());
+    public ApiResponse<List<UpdateResponse>> updateRankings() {
+        return ApiResponse.of(SuccessStatus.RANKINGUPDATE, rankingUpdateService.updateRankings());
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/converter/RankingConverter.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/converter/RankingConverter.java
@@ -1,0 +1,27 @@
+package BodyBuddy.demo.domain.avatar.converter;
+
+import BodyBuddy.demo.domain.avatar.dto.RankingResponse;
+import BodyBuddy.demo.domain.avatar.entity.Avatar;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RankingConverter {
+
+    public RankingResponse.GlobalRanking convertToGlobalRanking(Avatar avatar, int rank) {
+        return RankingResponse.GlobalRanking.builder()
+            .rank(rank)
+            .nickname(avatar.getMember().getNickname())
+            .rankingScore(avatar.getRankingScore())
+            .level(avatar.getLevel())
+            .build();
+    }
+
+    public RankingResponse.UpdateResponse convertToUpdateResponse(Avatar avatar, int points, int exp) {
+        return RankingResponse.UpdateResponse.builder()
+            .nickname(avatar.getMember().getNickname())
+            .rankingScore(avatar.getRankingScore())
+            .updatedPoints((long) points)
+            .updatedExp((long) exp)
+            .build();
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/dto/RankingResponse.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/dto/RankingResponse.java
@@ -1,0 +1,26 @@
+package BodyBuddy.demo.domain.avatar.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RankingResponse {
+
+    @Getter
+    @Builder
+    public static class GlobalRanking {
+        private final int rank;
+        private final String nickname;
+        private final Long rankingScore;
+        private final Long level;
+    }
+
+    @Getter
+    @Builder
+    public static class UpdateResponse {
+        private final String nickname;
+        private final Long rankingScore;
+        private final Long updatedPoints;
+        private final Long updatedExp;
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/entity/Avatar.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/entity/Avatar.java
@@ -14,7 +14,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
@@ -53,5 +52,12 @@ public class Avatar {
 	@OneToMany(mappedBy = "avatar", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<AvatarSkin> avatarSkins = new ArrayList<>();
 
+	public void updateRankingScore(int additionalScore) {
+		this.rankingScore += additionalScore;
+	}
 
+	public void updatePointsAndExp(int additionalPoints, int additionalExp) {
+		this.point = (this.point == null ? 0 : this.point) + additionalPoints;
+		this.exp = (this.exp == null ? 0 : this.exp) + additionalExp;
+	}
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/entity/Avatar.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/entity/Avatar.java
@@ -72,4 +72,9 @@ public class Avatar {
 		this.point = (this.point == null ? 0 : this.point) + additionalPoints;
 		this.exp = (this.exp == null ? 0 : this.exp) + additionalExp;
 	}
+
+	// 랭킹 스코어를 설정하는 메서드
+	public void setRankingScore(Long rankingScore) {
+		this.rankingScore = rankingScore;
+	}
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/repository/AvatarRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/repository/AvatarRepository.java
@@ -1,0 +1,48 @@
+package BodyBuddy.demo.domain.avatar.repository;
+
+import BodyBuddy.demo.domain.avatar.entity.Avatar;
+import BodyBuddy.demo.domain.gym.entity.Gym;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface AvatarRepository extends JpaRepository<Avatar, Long> {
+
+    Page<Avatar> findAllByOrderByRankingScoreDesc(Pageable pageable);
+
+    Page<Avatar> findByMemberGymOrderByRankingScoreDesc(Gym gym, Pageable pageable);
+
+    Optional<Avatar> findByMemberId(Long memberId);
+
+    List<Avatar> findAllByOrderByRankingScoreDesc();
+
+    @Query("""
+    SELECT COUNT(a) + 1
+    FROM Avatar a
+    WHERE a.rankingScore > (
+        SELECT rankingScore
+        FROM Avatar
+        WHERE member.id = :memberId
+    )
+    """)
+    int findGlobalRankForMember(@Param("memberId") Long memberId);
+
+
+    @Query("""
+    SELECT COUNT(a) + 1
+    FROM Avatar a
+    WHERE a.member.gym.id = :gymId
+      AND a.rankingScore > (
+          SELECT rankingScore
+          FROM Avatar
+          WHERE member.id = :memberId
+      )
+    """)
+    int findGymRankForMember(@Param("memberId") Long memberId, @Param("gymId") Long gymId);
+
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/scheduler/RankingScheduler.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/scheduler/RankingScheduler.java
@@ -1,11 +1,15 @@
 package BodyBuddy.demo.domain.avatar.scheduler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 @Component
 public class RankingScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(RankingScheduler.class);
 
     private final RestTemplate restTemplate;
 
@@ -15,14 +19,14 @@ public class RankingScheduler {
 
     @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 자정 실행
     public void triggerRankingUpdate() {
-        //TODO 프론트엔드와 협업할 시 Url 수정해야함
+        // TODO 프론트엔드와 협업할 시 Url 수정해야함
         String apiUrl = "http://localhost:8080/api/rankings/update"; // API 엔드포인트
 
         try {
             restTemplate.postForEntity(apiUrl, null, Void.class);
-            System.out.println("✅ 랭킹 업데이트가 성공적으로 되었습니다.");
+            logger.info("✅ 랭킹 업데이트가 성공적으로 완료되었습니다.");
         } catch (Exception e) {
-            System.err.println("❌ 랭킹 업데이트가 실패했습니다.: " + e.getMessage());
+            logger.error("❌ 랭킹 업데이트에 실패했습니다. 오류 메시지: {}", e.getMessage(), e);
         }
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/scheduler/RankingScheduler.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/scheduler/RankingScheduler.java
@@ -1,0 +1,28 @@
+package BodyBuddy.demo.domain.avatar.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class RankingScheduler {
+
+    private final RestTemplate restTemplate;
+
+    public RankingScheduler() {
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 자정 실행
+    public void triggerRankingUpdate() {
+        //TODO 프론트엔드와 협업할 시 Url 수정해야함
+        String apiUrl = "http://localhost:8080/api/rankings/update"; // API 엔드포인트
+
+        try {
+            restTemplate.postForEntity(apiUrl, null, Void.class);
+            System.out.println("✅ 랭킹 업데이트가 성공적으로 되었습니다.");
+        } catch (Exception e) {
+            System.err.println("❌ 랭킹 업데이트가 실패했습니다.: " + e.getMessage());
+        }
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/AvatarService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/AvatarService.java
@@ -1,0 +1,25 @@
+package BodyBuddy.demo.domain.avatar.service;
+
+import BodyBuddy.demo.domain.avatar.entity.Avatar;
+import BodyBuddy.demo.domain.avatar.repository.AvatarRepository;
+import BodyBuddy.demo.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AvatarService {
+
+    private final AvatarRepository avatarRepository;
+
+    public Avatar createDefaultAvatar(Member member) {
+        Avatar avatar = Avatar.builder()
+            .level(1L)
+            .exp(0L)
+            .point(0L)
+            .rankingScore(0L)
+            .member(member)
+            .build();
+        return avatarRepository.save(avatar);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/RankingService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/RankingService.java
@@ -1,0 +1,61 @@
+package BodyBuddy.demo.domain.avatar.service;
+
+import BodyBuddy.demo.domain.avatar.converter.RankingConverter;
+import BodyBuddy.demo.domain.avatar.dto.RankingResponse;
+import BodyBuddy.demo.domain.avatar.entity.Avatar;
+import BodyBuddy.demo.domain.avatar.repository.AvatarRepository;
+import BodyBuddy.demo.domain.gym.entity.Gym;
+import BodyBuddy.demo.domain.gym.service.GymService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final AvatarRepository avatarRepository;
+    private final GymService gymService;
+    private final RankingConverter rankingConverter;
+
+    public Page<RankingResponse.GlobalRanking> getGlobalRankings(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("rankingScore").descending());
+        Page<Avatar> avatars = avatarRepository.findAllByOrderByRankingScoreDesc(pageable);
+
+        return avatars.map(avatar -> rankingConverter.convertToGlobalRanking(avatar,
+            avatars.getContent().indexOf(avatar) + 1 + (page * size)));
+    }
+
+    public Page<RankingResponse.GlobalRanking> getGymRankings(Long gymId, int page, int size) {
+        Gym gym = gymService.validateGym(gymId);
+        Pageable pageable = PageRequest.of(page, size, Sort.by("rankingScore").descending());
+        Page<Avatar> avatars = avatarRepository.findByMemberGymOrderByRankingScoreDesc(gym,
+            pageable);
+
+        return avatars.map(avatar -> rankingConverter.convertToGlobalRanking(avatar,
+            avatars.getContent().indexOf(avatar) + 1 + (page * size)));
+    }
+
+    public RankingResponse.GlobalRanking getUserGlobalRanking(Long memberId) {
+        Avatar avatar = avatarRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        int rank = avatarRepository.findGlobalRankForMember(memberId);
+        return rankingConverter.convertToGlobalRanking(avatar, rank);
+    }
+
+    public RankingResponse.GlobalRanking getUserGymRanking(Long memberId, Long gymId) {
+        Avatar avatar = avatarRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        Gym gym = gymService.validateGym(gymId);
+
+        if (!avatar.getMember().getGym().equals(gym)) {
+            throw new IllegalArgumentException("회원은 해당 체육관에 속해 있지 않습니다.");
+        }
+
+        int rank = avatarRepository.findGymRankForMember(memberId, gymId);
+        return rankingConverter.convertToGlobalRanking(avatar, rank);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/RankingUpdateService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/RankingUpdateService.java
@@ -36,7 +36,17 @@ public class RankingUpdateService {
             rank++;
         }
 
+        // 모든 회원의 랭킹 스코어를 0으로 초기화
+        resetRankingScores(avatars);
+
         return responses;
+    }
+
+    private void resetRankingScores(List<Avatar> avatars) {
+        for (Avatar avatar : avatars) {
+            avatar.setRankingScore(0L); // 랭킹 스코어를 0으로 설정
+            avatarRepository.save(avatar);
+        }
     }
 
     private int calculatePoints(int rank) {

--- a/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/RankingUpdateService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/avatar/service/RankingUpdateService.java
@@ -1,0 +1,58 @@
+package BodyBuddy.demo.domain.avatar.service;
+
+import BodyBuddy.demo.domain.avatar.converter.RankingConverter;
+import BodyBuddy.demo.domain.avatar.dto.RankingResponse;
+import BodyBuddy.demo.domain.avatar.entity.Avatar;
+import BodyBuddy.demo.domain.avatar.repository.AvatarRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RankingUpdateService {
+
+    private final AvatarRepository avatarRepository;
+    private final RankingConverter rankingConverter;
+
+    @Transactional
+    public List<RankingResponse.UpdateResponse> updateRankings() {
+        List<Avatar> avatars = avatarRepository.findAllByOrderByRankingScoreDesc();
+        List<RankingResponse.UpdateResponse> responses = new ArrayList<>();
+
+        int rank = 1;
+        for (Avatar avatar : avatars) {
+            int points = calculatePoints(rank);
+            int exp = calculateExp(rank);
+
+            // 포인트와 경험치를 동시에 업데이트
+            avatar.updatePointsAndExp(points, exp);
+
+            avatarRepository.save(avatar);
+
+            responses.add(rankingConverter.convertToUpdateResponse(avatar, points, exp));
+            rank++;
+        }
+
+        return responses;
+    }
+
+    private int calculatePoints(int rank) {
+        if (rank == 1) return 500;
+        if (rank == 2) return 450;
+        if (rank == 3) return 400;
+        if (rank <= 5) return 300;
+        if (rank <= 10) return 250;
+        if (rank <= 20) return 200;
+        if (rank <= 50) return 120;
+        return 80;
+    }
+
+    private int calculateExp(int rank) {
+        return calculatePoints(rank);
+    }
+}
+
+

--- a/demo/src/main/java/BodyBuddy/demo/domain/gym/controller/GymController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/gym/controller/GymController.java
@@ -2,6 +2,8 @@ package BodyBuddy.demo.domain.gym.controller;
 
 import BodyBuddy.demo.domain.gym.entity.Gym;
 import BodyBuddy.demo.domain.gym.repository.GymRepository;
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
 import BodyBuddy.demo.global.common.commonEnum.Region;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,18 +22,18 @@ public class GymController {
     private final GymRepository gymRepository;
 
     @GetMapping("/regions")
-    public ResponseEntity<List<Region>> getAllRegions() {
-        return ResponseEntity.ok(List.of(Region.values()));
+    public ApiResponse<List<Region>> getAllRegions() {
+        return ApiResponse.of(SuccessStatus.REGIONSUCCESS, List.of(Region.values()));
     }
 
     @GetMapping
-    public ResponseEntity<List<Gym>> getGymsByRegion(@RequestParam(required = false) Region region) {
+    public ApiResponse<List<Gym>> getGymsByRegion(@RequestParam(required = false) Region region) {
         List<Gym> gyms;
         if (region != null) {
             gyms = gymRepository.findByRegion(region);
         } else {
             gyms = gymRepository.findAll(); // 모든 체육관을 조회하는 메서드가 필요합니다.
         }
-        return ResponseEntity.ok(gyms);
+        return ApiResponse.of(SuccessStatus.GYMSUCCESS, gyms);
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/gym/service/GymService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/gym/service/GymService.java
@@ -1,0 +1,18 @@
+package BodyBuddy.demo.domain.gym.service;
+
+import BodyBuddy.demo.domain.gym.entity.Gym;
+import BodyBuddy.demo.domain.gym.repository.GymRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GymService {
+
+    private final GymRepository gymRepository;
+
+    public Gym validateGym(Long gymId) {
+        return gymRepository.findById(gymId)
+            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 헬스장입니다."));
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/controller/InBodyToRankingScoreController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/controller/InBodyToRankingScoreController.java
@@ -2,8 +2,9 @@ package BodyBuddy.demo.domain.inbody.controller;
 
 import BodyBuddy.demo.domain.inbody.dto.InBodyToRankingScoreDTO;
 import BodyBuddy.demo.domain.inbody.service.InBodyToRankingScoreService;
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,8 +15,8 @@ public class InBodyToRankingScoreController {
     private final InBodyToRankingScoreService inBodyToRankingScoreService;
 
     @PostMapping("/ranking-score/{memberId}")
-    public ResponseEntity<InBodyToRankingScoreDTO> updateRankingScore(@PathVariable Long memberId) {
+    public ApiResponse<InBodyToRankingScoreDTO> updateRankingScore(@PathVariable Long memberId) {
         InBodyToRankingScoreDTO inBodyToRankingScoreDTO = inBodyToRankingScoreService.calculateAndSaveRankingScore(memberId);
-        return ResponseEntity.ok(inBodyToRankingScoreDTO);
+        return ApiResponse.of(SuccessStatus.RANKINGSCOREUPDATE, inBodyToRankingScoreDTO);
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/controller/InBodyToRankingScoreController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/controller/InBodyToRankingScoreController.java
@@ -7,13 +7,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/ranking-score")
+@RequestMapping("/api/inbody")
 @RequiredArgsConstructor
 public class InBodyToRankingScoreController {
 
     private final InBodyToRankingScoreService inBodyToRankingScoreService;
 
-    @PostMapping("/{memberId}")
+    @PostMapping("/ranking-score/{memberId}")
     public ResponseEntity<InBodyToRankingScoreDTO> updateRankingScore(@PathVariable Long memberId) {
         InBodyToRankingScoreDTO inBodyToRankingScoreDTO = inBodyToRankingScoreService.calculateAndSaveRankingScore(memberId);
         return ResponseEntity.ok(inBodyToRankingScoreDTO);

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/controller/InBodyToRankingScoreController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/controller/InBodyToRankingScoreController.java
@@ -1,0 +1,21 @@
+package BodyBuddy.demo.domain.inbody.controller;
+
+import BodyBuddy.demo.domain.inbody.dto.InBodyToRankingScoreDTO;
+import BodyBuddy.demo.domain.inbody.service.InBodyToRankingScoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/ranking-score")
+@RequiredArgsConstructor
+public class InBodyToRankingScoreController {
+
+    private final InBodyToRankingScoreService inBodyToRankingScoreService;
+
+    @PostMapping("/{memberId}")
+    public ResponseEntity<InBodyToRankingScoreDTO> updateRankingScore(@PathVariable Long memberId) {
+        InBodyToRankingScoreDTO inBodyToRankingScoreDTO = inBodyToRankingScoreService.calculateAndSaveRankingScore(memberId);
+        return ResponseEntity.ok(inBodyToRankingScoreDTO);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/converter/InBodyConverter.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/converter/InBodyConverter.java
@@ -1,0 +1,25 @@
+package BodyBuddy.demo.domain.inbody.converter;
+
+import BodyBuddy.demo.domain.inbody.dto.InBodyToRankingScoreDTO;
+import BodyBuddy.demo.domain.inbody.entity.InBody;
+
+import java.util.List;
+
+public class InBodyConverter {
+
+    public static InBodyToRankingScoreDTO toRankingScoreDTO(List<InBody> inBodyData, int calculatedScore) {
+        InBody current = inBodyData.get(0);
+        InBody previous = inBodyData.get(1);
+
+        return InBodyToRankingScoreDTO.builder()
+            .memberId(current.getMember().getId())
+            .currentWeight(current.getWeight())
+            .currentMuscle(current.getMuscle())
+            .currentBodyFat(current.getBodyFat())
+            .previousWeight(previous.getWeight())
+            .previousMuscle(previous.getMuscle())
+            .previousBodyFat(previous.getBodyFat())
+            .rankingScore(calculatedScore)
+            .build();
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/dto/InBodyToRankingScoreDTO.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/dto/InBodyToRankingScoreDTO.java
@@ -1,0 +1,17 @@
+package BodyBuddy.demo.domain.inbody.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InBodyToRankingScoreDTO {
+    private Long memberId;
+    private Float currentWeight;
+    private Float currentMuscle;
+    private Float currentBodyFat;
+    private Float previousWeight;
+    private Float previousMuscle;
+    private Float previousBodyFat;
+    private int rankingScore;
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/repository/InBodyRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/repository/InBodyRepository.java
@@ -1,0 +1,11 @@
+package BodyBuddy.demo.domain.inbody.repository;
+
+import BodyBuddy.demo.domain.inbody.entity.InBody;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InBodyRepository extends JpaRepository<InBody, Long> {
+    // 최신 두 개의 데이터를 가져오는 메서드
+    List<InBody> findTop2ByMemberIdOrderByCreatedAtDesc(Long memberId);
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/service/InBodyToRankingScoreService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/service/InBodyToRankingScoreService.java
@@ -1,0 +1,103 @@
+package BodyBuddy.demo.domain.inbody.service;
+
+import BodyBuddy.demo.domain.avatar.entity.Avatar;
+import BodyBuddy.demo.domain.inbody.converter.InBodyConverter;
+import BodyBuddy.demo.domain.inbody.dto.InBodyToRankingScoreDTO;
+import BodyBuddy.demo.domain.inbody.entity.InBody;
+import BodyBuddy.demo.domain.avatar.repository.AvatarRepository;
+import BodyBuddy.demo.domain.inbody.repository.InBodyRepository;
+import BodyBuddy.demo.global.common.commonEnum.Gender;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InBodyToRankingScoreService {
+
+    private final InBodyRepository inBodyRepository;
+    private final AvatarRepository avatarRepository;
+
+    @Transactional
+    public InBodyToRankingScoreDTO calculateAndSaveRankingScore(Long memberId) {
+        List<InBody> inBodyData = inBodyRepository.findTop2ByMemberIdOrderByCreatedAtDesc(memberId);
+
+        if (inBodyData.size() < 2) {
+            throw new IllegalArgumentException("랭크 점수 갱신하기에 분석할 수 있는 인바디 데이터 수가 2개 미만입니다.");
+        }
+
+        InBody current = inBodyData.get(0);
+        InBody previous = inBodyData.get(1);
+
+        int score = calculateRankingScore(current, previous, current.getMember().getGender());
+
+        Avatar avatar = avatarRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("멤버Id에 따른 아바타를 찾지 못했습니다.: " + memberId));
+
+        avatar.updateRankingScore(score);
+        avatarRepository.save(avatar);
+
+        return InBodyConverter.toRankingScoreDTO(inBodyData, score);
+    }
+
+    private int calculateRankingScore(InBody current, InBody previous, Gender gender) {
+        float weightChange = current.getWeight() - previous.getWeight();
+        float muscleChange = current.getMuscle() - previous.getMuscle();
+        float bodyFatChange = current.getBodyFat() - previous.getBodyFat();
+
+        int muscleScore = calculateMuscleScore(current.getMuscle(), gender, current.getMember().getHeight());
+        int bodyFatScore = calculateBodyFatScore(current.getBodyFat(), gender, current.getMember().getHeight());
+
+        return Math.round(muscleScore + bodyFatScore + weightChange * 2); // 정수로 반환
+    }
+
+    private int calculateMuscleScore(float muscle, Gender gender, float height) {
+        float[] standards = getMuscleStandards((int) height, gender); // 키를 정수로 변환
+        float standard = standards[1];
+
+        if (muscle < standard * 0.85) return 100;
+        if (muscle < standard) return Math.round(100 * 1.3f);
+        if (muscle <= standard * 1.15) return Math.round(100 * 1.7f);
+        if (muscle <= standard * 1.3) return 200;
+        return 300;
+    }
+
+    private int calculateBodyFatScore(float bodyFat, Gender gender, float height) {
+        float[] standards = getBodyFatStandards((int) height, gender); // 키를 정수로 변환
+        float standard = standards[1];
+
+        if (bodyFat < standard * 0.85) return Math.round(30 * 3f);
+        if (bodyFat < standard) return Math.round(30 * 2f);
+        if (bodyFat <= standard * 1.15) return Math.round(30 * 1.7f);
+        if (bodyFat <= standard * 1.3) return Math.round(30 * 1.3f);
+        return 30;
+    }
+
+    private float[] getMuscleStandards(int height, Gender gender) {
+        return switch (height) {
+            case 155 -> gender == Gender.MALE ? new float[]{19, 22} : new float[]{18, 22};
+            case 160 -> gender == Gender.MALE ? new float[]{21, 24} : new float[]{19, 24};
+            case 165 -> gender == Gender.MALE ? new float[]{23, 26} : new float[]{20, 25};
+            case 170 -> gender == Gender.MALE ? new float[]{24, 27} : new float[]{21, 26};
+            case 175 -> gender == Gender.MALE ? new float[]{25, 28} : new float[]{22, 27};
+            case 180 -> gender == Gender.MALE ? new float[]{26, 29} : new float[]{23, 28};
+            case 185 -> gender == Gender.MALE ? new float[]{27, 30} : new float[]{24, 29};
+            default -> new float[]{0, 0};
+        };
+    }
+
+    private float[] getBodyFatStandards(int height, Gender gender) {
+        return switch (height) {
+            case 155 -> gender == Gender.MALE ? new float[]{27, 31} : new float[]{15, 20};
+            case 160 -> gender == Gender.MALE ? new float[]{31, 35} : new float[]{17, 22};
+            case 165 -> gender == Gender.MALE ? new float[]{33, 37} : new float[]{19, 24};
+            case 170 -> gender == Gender.MALE ? new float[]{35, 39} : new float[]{21, 26};
+            case 175 -> gender == Gender.MALE ? new float[]{37, 41} : new float[]{23, 28};
+            case 180 -> gender == Gender.MALE ? new float[]{39, 43} : new float[]{25, 30};
+            case 185 -> gender == Gender.MALE ? new float[]{41, 45} : new float[]{27, 32};
+            default -> new float[]{0, 0};
+        };
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/controller/AuthController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/controller/AuthController.java
@@ -2,6 +2,8 @@ package BodyBuddy.demo.domain.member.controller;
 
 import BodyBuddy.demo.domain.member.dto.SignUpRequestDto;
 import BodyBuddy.demo.domain.member.service.MemberService;
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,35 +22,35 @@ public class AuthController {
      * 일반 회원 회원가입
      */
     @PostMapping("/members/signup")
-    public ResponseEntity<String> signupMember(@Valid @RequestBody SignUpRequestDto.MemberSignupRequest request) {
+    public ApiResponse<Void> signupMember(@Valid @RequestBody SignUpRequestDto.MemberSignupRequest request) {
         memberService.signupMember(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body("일반 회원 가입이 완료되었습니다.");
+        return ApiResponse.of(SuccessStatus.SIGNUP_SUCCESS, null);
     }
 
     /**
      * 트레이너 회원가입
      */
     @PostMapping("/trainers/signup")
-    public ResponseEntity<String> signupTrainer(@Valid @RequestBody SignUpRequestDto.TrainerSignupRequest request) {
+    public ApiResponse<Void> signupTrainer(@Valid @RequestBody SignUpRequestDto.TrainerSignupRequest request) {
         memberService.signupTrainer(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body("트레이너 회원 가입이 완료되었습니다.");
+        return ApiResponse.of(SuccessStatus.SIGNUP_SUCCESS, null);
     }
 
     /**
      * 로그인
      */
     @PostMapping("/login")
-    public ResponseEntity<String> login(@Valid @RequestBody SignUpRequestDto.MemberLoginRequest request) {
+    public ApiResponse<String> login(@Valid @RequestBody SignUpRequestDto.MemberLoginRequest request) {
         String token = memberService.login(request);
-        return ResponseEntity.ok(token);
+        return ApiResponse.of(SuccessStatus.LOGIN_SUCCESS, token);
     }
 
     /**
      * 회원 탈퇴
      */
     @DeleteMapping("/delete")
-    public ResponseEntity<String> deleteUser(@RequestParam String loginId) {
+    public ApiResponse<Void> deleteUser(@RequestParam String loginId) {
         memberService.deleteUser(loginId);
-        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
+        return ApiResponse.of(SuccessStatus.DELETE_ACCOUNT_SUCCESS, null);
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
@@ -12,7 +12,28 @@ import lombok.Getter;
 public enum SuccessStatus implements BaseCode {
 
 	// 일반적인 응답
-	_OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+	_OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+
+	// 로그인 관련 응답
+	LOGIN_SUCCESS(HttpStatus.OK, "AUTH2000", "로그인 성공입니다."),
+
+	// 회원가입 관련 응답
+	SIGNUP_SUCCESS(HttpStatus.OK,"AUTH2010", "회원가입 성공입니다."),
+
+	// 회원 탈퇴 관련 응답
+	DELETE_ACCOUNT_SUCCESS(HttpStatus.OK,"AUTH2020", "회원 탈퇴 성공입니다."),
+
+	// 랭킹 관련 응답
+	RANKINGSUCCESS(HttpStatus.OK, "RANKING2000", "랭킹 조회 성공입니다."),
+	RANKINGUPDATE(HttpStatus.OK, "RANKING2001", "랭킹 보너스 업데이트 성공입니다."),
+	RANKINGSCOREUPDATE(HttpStatus.OK, "RANKING2002", "랭크 점수 업데이트 성공입니다."),
+
+	//헬스장 관련 응답
+	GYMSUCCESS(HttpStatus.OK, "GYM200", "체육관 조회 성공입니다."),
+
+	//지역 관련 응답
+	REGIONSUCCESS(HttpStatus.OK, "REGION200", "지역 조회 성공입니다.");
+
 
 	private final HttpStatus httpStatus;
 	private final String code;


### PR DESCRIPTION
## **📌 Summary**
>사용자 랭킹 점수 및 보상 시스템을 구현하고, 최신 인바디 데이터를 기반으로 랭킹 점수 갱신 로직과 API를 추가하였습니다. 스프링 스케줄러를 사용해 자동으로 랭킹 업데이트 작업이 실행되도록 설정했으며, 프론트엔드와의 협업 시 URL 수정 필요 할 거 같습니다.
---

## **🔍 Related Issues**
>관련된 이슈 번호를 연결하세요. (없다면 "해당 없음" 작성)
  - #28 

---

## **🚀 Implementation Details**
>주요 변경 사항 및 구현 내용을 자세히 설명하세요.
### 1. 사용자 랭킹 조회 및 페이징
  - 글로벌 및 체육관 기준으로 사용자 랭킹을 조회할 수 있는 API 구현.
  - 사용자별 랭킹 점수와 순위를 확인하는 기능 추가.
### 2. 포인트 및 경험치 분배 로직
  - 랭킹에 따른 포인트 및 경험치를 사용자에게 분배하는 비즈니스 로직 추가.
  - Spring Scheduler를 사용하여 매주 월요일 자정에 자동으로 보상이 지급되도록 설정.
### 3. 최신 인바디 데이터 기반 랭킹 점수 갱신
   - 사용자의 최신 두 개의 인바디 데이터를 조회하고, 변화량을 기반으로 랭킹 점수를 갱신하는 비즈니스 로직 추가.
   - POST /api/inbody/ranking-score API로 랭킹 점수를 업데이트.
---

## **💡 Notes**
>이 PR에 대한 추가적인 주석이나 팀원이 참고해야 할 사항을 기록하세요.
  - **(중요)** 사용자 경험치 레벨 업 로직과 연계 아직 안해놓음 추후 구현 예정.

---
## **🧪TEST**
![특정 사용자 랭킹](https://github.com/user-attachments/assets/3dc6feea-5db0-4855-870b-1472fc94a5a3)
특정 사용자 랭킹 조회
![특정 헬스장 전체 랭킹](https://github.com/user-attachments/assets/e6b942d6-1336-4302-8223-aa85d9826aff)
특정 헬스장 전체 랭킹 조회
![특정 헬스장의 특정 사용자 랭킹](https://github.com/user-attachments/assets/1326e7fb-0c86-42e1-a9dd-c1b941aaf7a7)
![특정 헬스장의 특정 사용자 랭킹 2 (페이징 조회)](https://github.com/user-attachments/assets/fe8f71fb-918d-494c-8af9-4ef2780b2686)
특정 헬스장의 특정 사용자 랭킹 조회(페이징 처리)
![전체 랭킹 조회](https://github.com/user-attachments/assets/6117d916-b418-4fbe-90b8-12177398d12f)
![전체 랭킹 조회 2 (페이징 조회)](https://github.com/user-attachments/assets/a04c5781-323f-4fed-a0c7-3c4539d7ddc6)
전체 랭킹 조회(페이징 처리)
![인바디 데이터 비교를 통한 랭크 점수 지급](https://github.com/user-attachments/assets/e14dad80-b764-494f-9248-c6633ef71a58)
인바디 데이터 비교를 통한 랭크 점수 지급
![랭킹 보상 업데이트](https://github.com/user-attachments/assets/901117fc-36fb-49d6-9c62-24fa058add5d)
랭킹 보상 업데이트



