### PR TITLE
[FEAT] 트레이너 페이지 및 뱃지, 포트폴리오(약력) 구현

### DIFF
--- a/demo/src/main/java/BodyBuddy/demo/domain/badge/controller/BadgeController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/badge/controller/BadgeController.java
@@ -1,0 +1,31 @@
+package BodyBuddy.demo.domain.badge.controller;
+
+import BodyBuddy.demo.domain.badge.converter.BadgeConverter;
+import BodyBuddy.demo.domain.badge.dto.BadgeResponseDto;
+import BodyBuddy.demo.domain.badge.entity.Badge;
+import BodyBuddy.demo.domain.badge.service.BadgeService;
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/badges")
+public class BadgeController {
+
+    private final BadgeService badgeService;
+    private final BadgeConverter badgeConverter;
+
+    /**
+     * 특정 트레이너의 뱃지 리스트 조회
+     */
+    @GetMapping("/trainers/{trainerId}")
+    public ApiResponse<List<BadgeResponseDto>> getTrainerBadges(@PathVariable Long trainerId) {
+        List<Badge> badges = badgeService.checkAndAssignBadges(trainerId);
+        List<BadgeResponseDto> badgeDtos = badgeConverter.convertToDtoList(badges);
+        return ApiResponse.of(SuccessStatus.BADGE_SUCCESS, badgeDtos);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/badge/converter/BadgeConverter.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/badge/converter/BadgeConverter.java
@@ -1,0 +1,33 @@
+package BodyBuddy.demo.domain.badge.converter;
+
+import BodyBuddy.demo.domain.badge.dto.BadgeResponseDto;
+import BodyBuddy.demo.domain.badge.entity.Badge;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class BadgeConverter {
+
+    /**
+     * 뱃지 엔티티를 DTO로 변환
+     */
+    public BadgeResponseDto convertToDto(Badge badge) {
+        return BadgeResponseDto.builder()
+                .id(badge.getId())
+                .badgeName(badge.getBadgeName())
+                .badgeDescription(badge.getBadgeDescription())
+                .iconUrl(badge.getIconUrl())
+                .build();
+    }
+
+    /**
+     * 뱃지 엔티티 리스트를 DTO 리스트로 변환
+     */
+    public List<BadgeResponseDto> convertToDtoList(List<Badge> badges) {
+        return badges.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/badge/dto/BadgeResponseDto.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/badge/dto/BadgeResponseDto.java
@@ -1,0 +1,11 @@
+package BodyBuddy.demo.domain.badge.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BadgeResponseDto(
+        Long id,
+        String badgeName,
+        String badgeDescription,
+        String iconUrl
+) {}

--- a/demo/src/main/java/BodyBuddy/demo/domain/badge/entity/Badge.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/badge/entity/Badge.java
@@ -29,12 +29,27 @@ public class Badge {
 	private Long id;
 
 	@Column(nullable = false)
-	private String name; // Badge name
+	private String badgeName;
 
-	private String iconUrl; // URL for badge icon (optional)
+	@Column(nullable = false)
+	private String badgeDescription;
+
+	private String iconUrl; //TODO 뱃지 아이콘 URL은 따로 분리해서 각 뱃지에 대한 아이콘의 URL을 DB에 저장해놓고 불러오는 식으로 추후에 구현
+							// 현재는 테스트 URL을 사용.
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "trainer_id", nullable = false)
 	private Trainer trainer;
 
+	public void assignTrainer(Trainer trainer) {
+		this.trainer = trainer;
+		trainer.getBadges().add(this);
+	}
+
+	public Badge(String badgeName, String badgeDescription, String iconUrl, Trainer trainer) {
+		this.badgeName = badgeName;
+		this.badgeDescription = badgeDescription;
+		this.iconUrl = iconUrl;
+		this.trainer = trainer;
+	}
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/badge/repository/BadgeRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/badge/repository/BadgeRepository.java
@@ -1,0 +1,7 @@
+package BodyBuddy.demo.domain.badge.repository;
+
+import BodyBuddy.demo.domain.badge.entity.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/badge/service/BadgeService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/badge/service/BadgeService.java
@@ -1,0 +1,166 @@
+package BodyBuddy.demo.domain.badge.service;
+
+import BodyBuddy.demo.domain.badge.entity.Badge;
+import BodyBuddy.demo.domain.badge.repository.BadgeRepository;
+import BodyBuddy.demo.domain.inbody.entity.InBody;
+import BodyBuddy.demo.domain.inbody.repository.InBodyRepository;
+import BodyBuddy.demo.domain.member.entity.Member;
+import BodyBuddy.demo.domain.member.repository.MemberRepository;
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import BodyBuddy.demo.domain.trainer.repository.TrainerRepository;
+import BodyBuddy.demo.global.common.commonEnum.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+
+    private final BadgeRepository badgeRepository;
+    private final TrainerRepository trainerRepository;
+    private final MemberRepository memberRepository;
+    private final InBodyRepository inBodyRepository;
+
+    /**
+     * 트레이너 조건에 따라 뱃지 확인 및 추가
+     */
+    public List<Badge> checkAndAssignBadges(Long trainerId) {
+        Trainer trainer = trainerRepository.findById(trainerId)
+                .orElseThrow(() -> new IllegalArgumentException("트레이너를 찾을 수 없습니다."));
+
+        List<Badge> newBadges = new ArrayList<>();
+        
+        // 1. 누적 회원 수 기준
+        Badge memberBadge = checkCumulativeMembersBadge(trainerId);
+        if (memberBadge != null) {
+            memberBadge.assignTrainer(trainer);
+            badgeRepository.save(memberBadge);
+            newBadges.add(memberBadge);
+        }
+
+        // 2. 다이어트 메이커 기준
+        Badge dietBadge = checkDietMakerBadge(trainerId);
+        if (dietBadge != null) {
+            dietBadge.assignTrainer(trainer);
+            badgeRepository.save(dietBadge);
+            newBadges.add(dietBadge);
+        }
+
+        // 3. 근육 마스터 기준
+        Badge muscleBadge = checkMuscleMasterBadge(trainerId);
+        if (muscleBadge != null) {
+            muscleBadge.assignTrainer(trainer);
+            badgeRepository.save(muscleBadge);
+            newBadges.add(muscleBadge);
+        }
+
+        return newBadges;
+    }
+
+    /**
+     * 누적 회원 수 기준 뱃지 확인
+     */
+    private Badge checkCumulativeMembersBadge(Long trainerId) {
+        int memberCount = memberRepository.countByTrainerId(trainerId);
+        String iconUrl = null;
+
+        if (memberCount >= 200) {
+            iconUrl = "https://example.com/icons/200.png";
+            return new Badge("200명 달성", "누적 인원 200명 달성", iconUrl, null);
+        } else if (memberCount >= 100) {
+            iconUrl = "https://example.com/icons/100.png";
+            return new Badge("100명 달성", "누적 인원 100명 달성", iconUrl, null);
+        } else if (memberCount >= 50) {
+            iconUrl = "https://example.com/icons/50.png";
+            return new Badge("50명 달성", "누적 인원 50명 달성", iconUrl, null);
+        } else if (memberCount >= 25) {
+            iconUrl = "https://example.com/icons/25.png";
+            return new Badge("25명 달성", "누적 인원 25명 달성", iconUrl, null);
+        } else if (memberCount >= 10) {
+            iconUrl = "https://example.com/icons/10.png";
+            return new Badge("10명 달성", "누적 인원 10명 달성", iconUrl, null);
+        } else if (memberCount >= 5) {
+            iconUrl = "https://example.com/icons/5.png";
+            return new Badge("5명 달성", "누적 인원 5명 달성", iconUrl, null);
+        }
+
+        return null;
+    }
+
+    /**
+     * 다이어트 메이커 기준 뱃지 확인
+     */
+    private Badge checkDietMakerBadge(Long trainerId) {
+        List<Member> members = memberRepository.findByTrainerId(trainerId);
+
+        for (Member member : members) {
+            List<InBody> inBodies = inBodyRepository.findByMemberIdOrderByCreatedAtAsc(member.getId());
+            if (inBodies.size() < 2) continue; // 데이터가 부족한 경우
+
+            float initialWeight = inBodies.get(0).getWeight();
+            float latestWeight = inBodies.get(inBodies.size() - 1).getWeight();
+            float weightLoss = initialWeight - latestWeight;
+
+            if (weightLoss >= 20) {
+                String iconUrl = "https://example.com/icons/diet20.png";
+                return new Badge("다이어트 메이커 (20kg)", "체중 20kg 감소 달성", iconUrl, null);
+            } else if (weightLoss >= 10) {
+                String iconUrl = "https://example.com/icons/diet10.png";
+                return new Badge("다이어트 메이커 (10kg)", "체중 10kg 감소 달성", iconUrl, null);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 근육 마스터 기준 뱃지 확인
+     */
+    private Badge checkMuscleMasterBadge(Long trainerId) {
+        List<Member> members = memberRepository.findByTrainerId(trainerId);
+
+        for (Member member : members) {
+            List<InBody> inBodies = inBodyRepository.findByMemberIdOrderByCreatedAtDesc(member.getId());
+            if (inBodies.isEmpty()) continue; // 데이터가 없는 경우
+
+            InBody latestInBody = inBodies.get(0);
+            float muscleMass = latestInBody.getMuscle();
+            float standardMuscleMass = calculateStandardMuscleMass(member.getHeight(), member.getGender());
+
+            if (muscleMass >= standardMuscleMass) {
+                String iconUrl = "https://example.com/icons/muscle.png";
+                return new Badge("근육 마스터", "골격근량 표준 이상 증가", iconUrl, null);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 키에 따른 표준 골격근량 계산
+     */
+    private float calculateStandardMuscleMass(float height, Gender gender) {
+        if (gender == Gender.MALE) {
+            if (height <= 155) return 20.5f; // (19 + 22) / 2
+            else if (height <= 160) return 22.5f; // (21 + 24) / 2
+            else if (height <= 165) return 24.5f; // (23 + 26) / 2
+            else if (height <= 170) return 25.5f; // (24 + 27) / 2
+            else if (height <= 175) return 26.5f; // (25 + 28) / 2
+            else if (height <= 180) return 27.5f; // (26 + 29) / 2
+            else if (height <= 185) return 28.5f; // (27 + 30) / 2
+            else return 28.5f; // 최대값 이상일 때
+        } else if (gender == Gender.FEMALE) {
+            if (height <= 155) return 20f; // (18 + 22) / 2
+            else if (height <= 160) return 21.5f; // (19 + 24) / 2
+            else if (height <= 165) return 22.5f; // (20 + 25) / 2
+            else if (height <= 170) return 23.5f; // (21 + 26) / 2
+            else if (height <= 175) return 24.5f; // (22 + 27) / 2
+            else if (height <= 180) return 25.5f; // (23 + 28) / 2
+            else if (height <= 185) return 26.5f; // (24 + 29) / 2
+            else return 26.5f; // 최대값 이상일 때
+        }
+        throw new IllegalArgumentException("잘못된 성별입니다.");
+    }
+
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/inbody/repository/InBodyRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/inbody/repository/InBodyRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface InBodyRepository extends JpaRepository<InBody, Long> {
     // 최신 두 개의 데이터를 가져오는 메서드
     List<InBody> findTop2ByMemberIdOrderByCreatedAtDesc(Long memberId);
+    List<InBody> findByMemberIdOrderByCreatedAtAsc(Long memberId);
+    List<InBody> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/matchingAuthentication/repository/MatchingAuthenticationRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/matchingAuthentication/repository/MatchingAuthenticationRepository.java
@@ -13,9 +13,3 @@ public interface MatchingAuthenticationRepository extends JpaRepository<Matching
 
 	long countByTrainerAndStatus(Trainer trainer, AuthenticationRequest status);
 }
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import BodyBuddy.demo.domain.matchingAuthentication.entity.MatchingAuthentication;
-
-public interface MatchingAuthenticationRepository extends JpaRepository<MatchingAuthentication, Long> {
-}

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/dto/SignUpRequestDto.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/dto/SignUpRequestDto.java
@@ -6,13 +6,17 @@ import BodyBuddy.demo.global.common.commonEnum.Region;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 public class SignUpRequestDto {
 
+    @NoArgsConstructor(force = true)
+    @AllArgsConstructor
     @Getter
     @Builder
     public static class MemberSignupRequest {

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/repository/MemberRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/repository/MemberRepository.java
@@ -4,11 +4,14 @@ package BodyBuddy.demo.domain.member.repository;
 import BodyBuddy.demo.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
     boolean existsByNickname(String nickname); // 닉네임 중복 검사
+    int countByTrainerId(Long trainerId);
+    List<Member> findByTrainerId(Long trainerId);
 }
 

--- a/demo/src/main/java/BodyBuddy/demo/domain/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/portfolio/controller/PortfolioController.java
@@ -1,0 +1,40 @@
+package BodyBuddy.demo.domain.portfolio.controller;
+
+import BodyBuddy.demo.domain.portfolio.dto.PortfolioRequest;
+import BodyBuddy.demo.domain.portfolio.dto.PortfolioResponse;
+import BodyBuddy.demo.domain.portfolio.entity.Portfolio;
+import BodyBuddy.demo.domain.portfolio.service.PortfolioService;
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trainers/{trainerId}/portfolios")
+public class PortfolioController {
+
+    private final PortfolioService portfolioService;
+
+    /**
+     * 트레이너 포트폴리오 등록
+     */
+    @PostMapping
+    public ApiResponse<Void> createPortfolio(@PathVariable Long trainerId, @RequestBody PortfolioRequest request) {
+        portfolioService.createPortfolio(trainerId, request);
+        return ApiResponse.of(SuccessStatus.PORTFOLIO_CREATED, null);
+    }
+
+    /**
+     * 트레이너 포트폴리오 수정
+     */
+    @PutMapping("/{portfolioId}")
+    public ApiResponse<Void> updatePortfolio(
+            @PathVariable Long trainerId,
+            @PathVariable Long portfolioId,
+            @RequestBody PortfolioRequest request) {
+
+        portfolioService.updatePortfolio(trainerId, portfolioId, request);
+        return ApiResponse.of(SuccessStatus.PORTFOLIO_UPDATED, null);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/portfolio/converter/PortfolioConverter.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/portfolio/converter/PortfolioConverter.java
@@ -1,0 +1,31 @@
+package BodyBuddy.demo.domain.portfolio.converter;
+
+import BodyBuddy.demo.domain.portfolio.dto.PortfolioRequest;
+import BodyBuddy.demo.domain.portfolio.dto.PortfolioResponse;
+import BodyBuddy.demo.domain.portfolio.entity.Portfolio;
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortfolioConverter {
+
+    public Portfolio toEntity(PortfolioRequest request, Trainer trainer) {
+        return Portfolio.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .trainer(trainer)
+                .build();
+    }
+
+    public void updatePortfolio(Portfolio portfolio, PortfolioRequest request) {
+        portfolio.update(request.getTitle(), request.getDescription());
+    }
+
+    public PortfolioResponse toResponse(Portfolio portfolio) {
+        return PortfolioResponse.builder()
+                .id(portfolio.getId())
+                .title(portfolio.getTitle())
+                .description(portfolio.getDescription())
+                .build();
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/portfolio/dto/PortfolioRequest.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/portfolio/dto/PortfolioRequest.java
@@ -1,0 +1,11 @@
+package BodyBuddy.demo.domain.portfolio.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PortfolioRequest {
+    private String title;
+    private String description;
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/portfolio/dto/PortfolioResponse.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/portfolio/dto/PortfolioResponse.java
@@ -1,0 +1,12 @@
+package BodyBuddy.demo.domain.portfolio.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PortfolioResponse {
+    private Long id;
+    private String title;
+    private String description;
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/portfolio/entity/Portfolio.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/portfolio/entity/Portfolio.java
@@ -1,0 +1,30 @@
+package BodyBuddy.demo.domain.portfolio.entity;
+
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "Portfolio")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Portfolio {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "trainer_id")
+    private Trainer trainer;
+
+    public void update(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/portfolio/repository/PortfolioRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/portfolio/repository/PortfolioRepository.java
@@ -1,0 +1,7 @@
+package BodyBuddy.demo.domain.portfolio.repository;
+
+import BodyBuddy.demo.domain.portfolio.entity.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/portfolio/service/PortfolioService.java
@@ -1,0 +1,48 @@
+package BodyBuddy.demo.domain.portfolio.service;
+
+import BodyBuddy.demo.domain.portfolio.converter.PortfolioConverter;
+import BodyBuddy.demo.domain.portfolio.dto.PortfolioRequest;
+import BodyBuddy.demo.domain.portfolio.dto.PortfolioResponse;
+import BodyBuddy.demo.domain.portfolio.entity.Portfolio;
+import BodyBuddy.demo.domain.portfolio.repository.PortfolioRepository;
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import BodyBuddy.demo.domain.trainer.repository.TrainerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioService {
+
+    private final PortfolioRepository portfolioRepository;
+    private final TrainerRepository trainerRepository;
+    private final PortfolioConverter portfolioConverter;
+
+    /**
+     * 트레이너 포트폴리오 등록
+     */
+    @Transactional
+    public void createPortfolio(Long trainerId, PortfolioRequest request) {
+        Trainer trainer = trainerRepository.findById(trainerId)
+                .orElseThrow(() -> new IllegalArgumentException("트레이너를 찾을 수 없습니다."));
+
+        Portfolio portfolio = portfolioConverter.toEntity(request, trainer);
+        portfolioRepository.save(portfolio);
+    }
+
+    /**
+     * 트레이너 포트폴리오 수정
+     */
+    @Transactional
+    public void updatePortfolio(Long trainerId, Long portfolioId, PortfolioRequest request) {
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다."));
+
+        if (!portfolio.getTrainer().getId().equals(trainerId)) {
+            throw new IllegalStateException("포트폴리오 수정 권한이 없습니다.");
+        }
+
+        portfolioConverter.updatePortfolio(portfolio, request);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/controller/TrainerController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/controller/TrainerController.java
@@ -1,0 +1,34 @@
+package BodyBuddy.demo.domain.trainer.controller;
+
+import BodyBuddy.demo.domain.gym.entity.Gym;
+import BodyBuddy.demo.domain.gym.repository.GymRepository;
+import BodyBuddy.demo.domain.trainer.converter.TrainerConverter;
+import BodyBuddy.demo.domain.trainer.dto.TrainerResponseDto;
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trainers")
+public class TrainerController {
+
+    private final GymRepository gymRepository;
+    private final TrainerConverter trainerConverter;
+
+    /**
+     * 특정 헬스장에 등록된 트레이너 목록을 반환하는 API (실명 및 나이 포함)
+     */
+    @GetMapping("/list/{gymId}")
+    public ApiResponse<List<TrainerResponseDto>> getTrainersByGym(@PathVariable Long gymId) {
+        Gym gym = gymRepository.findById(gymId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 헬스장이 존재하지 않습니다."));
+
+        List<TrainerResponseDto> trainers = trainerConverter.convertToTrainerDtoList(gym.getTrainers());
+
+        return ApiResponse.of(SuccessStatus.TRAINERS_BY_GYM_SUCCESS, trainers);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/controller/TrainerController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/controller/TrainerController.java
@@ -10,17 +10,45 @@ import org.springframework.web.bind.annotation.RestController;
 
 import BodyBuddy.demo.domain.trainer.dto.TrainerMyPageResponseDto;
 import BodyBuddy.demo.domain.trainer.dto.UpdateProfileImageRequestDto;
+import BodyBuddy.demo.domain.gym.entity.Gym;
+import BodyBuddy.demo.domain.gym.repository.GymRepository;
+import BodyBuddy.demo.domain.trainer.converter.TrainerConverter;
+import BodyBuddy.demo.domain.trainer.dto.TrainerResponse;
+import BodyBuddy.demo.domain.trainer.dto.TrainerResponseDto;
 import BodyBuddy.demo.domain.trainer.service.TrainerService;
 import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/api/trainer")
 @RequiredArgsConstructor
+@RequestMapping("/api/trainer")
 public class TrainerController {
 
-	private final TrainerService trainerService;
+    private final GymRepository gymRepository;
+    private final TrainerConverter trainerConverter;
+    private final TrainerService trainerService;
+
+    /**
+     * 특정 헬스장에 등록된 트레이너 목록을 반환하는 API (실명 및 나이 포함)
+     */
+    @GetMapping("/list/{gymId}")
+    public ApiResponse<List<TrainerResponseDto>> getTrainersByGym(@PathVariable Long gymId) {
+        Gym gym = gymRepository.findById(gymId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 헬스장이 존재하지 않습니다."));
+
+        List<TrainerResponseDto> trainers = trainerConverter.convertToTrainerDtoList(gym.getTrainers());
+
+        return ApiResponse.of(SuccessStatus.TRAINERS_BY_GYM_SUCCESS, trainers);
+    }
+
+    @GetMapping("/details/{trainerId}")
+    public ApiResponse<TrainerResponse> getTrainerDetails(@PathVariable Long trainerId) {
+        return ApiResponse.of(SuccessStatus.TRAINER_INFO_SUCCESS, trainerService.getTrainerDetails(trainerId));
+    }
 
 	/**
 	 * 트레이너 마이페이지 정보 조회

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/controller/TrainerController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/controller/TrainerController.java
@@ -3,7 +3,9 @@ package BodyBuddy.demo.domain.trainer.controller;
 import BodyBuddy.demo.domain.gym.entity.Gym;
 import BodyBuddy.demo.domain.gym.repository.GymRepository;
 import BodyBuddy.demo.domain.trainer.converter.TrainerConverter;
+import BodyBuddy.demo.domain.trainer.dto.TrainerResponse;
 import BodyBuddy.demo.domain.trainer.dto.TrainerResponseDto;
+import BodyBuddy.demo.domain.trainer.service.TrainerService;
 import BodyBuddy.demo.global.apiPayload.ApiResponse;
 import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ public class TrainerController {
 
     private final GymRepository gymRepository;
     private final TrainerConverter trainerConverter;
+    private final TrainerService trainerService;
 
     /**
      * 특정 헬스장에 등록된 트레이너 목록을 반환하는 API (실명 및 나이 포함)
@@ -30,5 +33,10 @@ public class TrainerController {
         List<TrainerResponseDto> trainers = trainerConverter.convertToTrainerDtoList(gym.getTrainers());
 
         return ApiResponse.of(SuccessStatus.TRAINERS_BY_GYM_SUCCESS, trainers);
+    }
+
+    @GetMapping("/{trainerId}")
+    public ApiResponse<TrainerResponse> getTrainerDetails(@PathVariable Long trainerId) {
+        return ApiResponse.of(SuccessStatus.TRAINER_INFO_SUCCESS, trainerService.getTrainerDetails(trainerId));
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/converter/TrainerConverter.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/converter/TrainerConverter.java
@@ -1,5 +1,9 @@
 package BodyBuddy.demo.domain.trainer.converter;
 
+import BodyBuddy.demo.domain.badge.entity.Badge;
+import BodyBuddy.demo.domain.member.entity.Member;
+import BodyBuddy.demo.domain.portfolio.entity.Portfolio;
+import BodyBuddy.demo.domain.trainer.dto.TrainerResponse;
 import BodyBuddy.demo.domain.trainer.dto.TrainerResponseDto;
 import BodyBuddy.demo.domain.trainer.entity.Trainer;
 import org.springframework.stereotype.Component;
@@ -11,6 +15,51 @@ import java.util.stream.Collectors;
 
 @Component
 public class TrainerConverter {
+
+    public TrainerResponse convertToTrainerResponse(Trainer trainer) {
+        return TrainerResponse.builder()
+                .realName(trainer.getRealName())
+                .age(calculateAge(trainer.getBirthday()))
+                .gender(trainer.getGender())
+                .height(trainer.getHeight())
+                .weight(trainer.getWeight())
+                .region(trainer.getRegion())
+                .gymName(trainer.getGym() != null ? trainer.getGym().getName() : "소속 없음")
+                .badges(convertBadges(trainer.getBadges()))
+                .portfolios(convertPortfolios(trainer.getPortfolios()))
+                .members(convertMembers(trainer.getMembers()))
+                .build();
+    }
+
+    private List<TrainerResponse.BadgeInfo> convertBadges(List<Badge> badges) {
+        return badges.stream()
+                .map(badge -> TrainerResponse.BadgeInfo.builder()
+                        .id(badge.getId())
+                        .badgeName(badge.getBadgeName())
+                        .badgeDescription(badge.getBadgeDescription())
+                        .iconUrl(badge.getIconUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private List<TrainerResponse.PortfolioInfo> convertPortfolios(List<Portfolio> portfolios) {
+        return portfolios.stream()
+                .map(portfolio -> TrainerResponse.PortfolioInfo.builder()
+                        .id(portfolio.getId())
+                        .title(portfolio.getTitle())
+                        .description(portfolio.getDescription())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private List<TrainerResponse.MemberInfo> convertMembers(List<Member> members) {
+        return members.stream()
+                .map(member -> TrainerResponse.MemberInfo.builder()
+                        .id(member.getId())
+                        .nickname(member.getNickname())
+                        .build())
+                .collect(Collectors.toList());
+    }
 
     /**
      * 트레이너 엔티티를 TrainerResponseDto 리스트로 변환

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/converter/TrainerConverter.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/converter/TrainerConverter.java
@@ -1,0 +1,40 @@
+package BodyBuddy.demo.domain.trainer.converter;
+
+import BodyBuddy.demo.domain.trainer.dto.TrainerResponseDto;
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class TrainerConverter {
+
+    /**
+     * 트레이너 엔티티를 TrainerResponseDto 리스트로 변환
+     */
+    public List<TrainerResponseDto> convertToTrainerDtoList(List<Trainer> trainers) {
+        return trainers.stream()
+                .map(this::convertToTrainerDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 트레이너 엔티티를 TrainerResponseDto로 변환
+     */
+    public TrainerResponseDto convertToTrainerDto(Trainer trainer) {
+        return TrainerResponseDto.builder()
+                .realName(trainer.getRealName())
+                .age(calculateAge(trainer.getBirthday()))
+                .build();
+    }
+
+    /**
+     * 생년월일을 기반으로 현재 만 나이 계산
+     */
+    private int calculateAge(LocalDate birthday) {
+        return Period.between(birthday, LocalDate.now()).getYears();
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/dto/TrainerResponse.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/dto/TrainerResponse.java
@@ -1,0 +1,47 @@
+package BodyBuddy.demo.domain.trainer.dto;
+
+import BodyBuddy.demo.global.common.commonEnum.Gender;
+import BodyBuddy.demo.global.common.commonEnum.Region;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TrainerResponse {
+    private String realName;
+    private int age;
+    private Gender gender;
+    private Float height;
+    private Float weight;
+    private Region region;
+    private String gymName;
+    private List<BadgeInfo> badges;
+    private List<PortfolioInfo> portfolios;
+    private List<MemberInfo> members;
+
+    @Getter
+    @Builder
+    public static class BadgeInfo {
+        private Long id;
+        private String badgeName;
+        private String badgeDescription;
+        private String iconUrl;
+    }
+
+    @Getter
+    @Builder
+    public static class PortfolioInfo {
+        private Long id;
+        private String title;
+        private String description;
+    }
+
+    @Getter
+    @Builder
+    public static class MemberInfo {
+        private Long id;
+        private String nickname;
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/dto/TrainerResponseDto.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/dto/TrainerResponseDto.java
@@ -1,0 +1,8 @@
+package BodyBuddy.demo.domain.trainer.dto;
+import lombok.Builder;
+
+@Builder
+public record TrainerResponseDto(
+        String realName,
+        int age
+) {}

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/entity/Trainer.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/entity/Trainer.java
@@ -7,6 +7,7 @@ import java.util.List;
 import BodyBuddy.demo.domain.badge.entity.Badge;
 import BodyBuddy.demo.domain.gym.entity.Gym;
 import BodyBuddy.demo.domain.member.entity.Member;
+import BodyBuddy.demo.domain.portfolio.entity.Portfolio;
 import BodyBuddy.demo.global.common.commonEnum.Gender;
 import BodyBuddy.demo.global.common.commonEnum.Region;
 import jakarta.persistence.CascadeType;
@@ -71,7 +72,6 @@ public class Trainer {
 	@Column(nullable = false, unique = true)
 	private String uuid;  // 추가적인 고유 값(랜덤 UUID)
 
-	private int badgeCount; // 뱃지 개수
 
 	@ManyToOne(optional = true) // 체육관 소속 정보 (nullable)
 	@JoinColumn(name = "gym_id", nullable = true)
@@ -81,7 +81,10 @@ public class Trainer {
 	private List<Member> members = new ArrayList<>();
 
 	@OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Badge> badges=new ArrayList<>();
+	private List<Badge> badges = new ArrayList<>();
+
+	@OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Portfolio> portfolios = new ArrayList<>();
 
 	public void setPassword(String password) {
 		this.password = password;

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/service/TrainerService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/service/TrainerService.java
@@ -1,0 +1,22 @@
+package BodyBuddy.demo.domain.trainer.service;
+
+import BodyBuddy.demo.domain.trainer.converter.TrainerConverter;
+import BodyBuddy.demo.domain.trainer.dto.TrainerResponse;
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import BodyBuddy.demo.domain.trainer.repository.TrainerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TrainerService {
+
+    private final TrainerRepository trainerRepository;
+    private final TrainerConverter trainerConverter;
+
+    public TrainerResponse getTrainerDetails(Long trainerId) {
+        Trainer trainer = trainerRepository.findById(trainerId)
+                .orElseThrow(() -> new IllegalArgumentException("트레이너를 찾을 수 없습니다."));
+        return trainerConverter.convertToTrainerResponse(trainer);
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/service/TrainerService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/service/TrainerService.java
@@ -2,16 +2,15 @@ package BodyBuddy.demo.domain.trainer.service;
 
 import BodyBuddy.demo.domain.trainer.converter.TrainerConverter;
 import BodyBuddy.demo.domain.trainer.dto.TrainerResponse;
+import BodyBuddy.demo.domain.trainer.repository.TrainerRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import BodyBuddy.demo.domain.matchingAuthentication.repository.MatchingAuthenticationRepository;
 import BodyBuddy.demo.domain.trainer.dto.TrainerMyPageResponseDto;
 import BodyBuddy.demo.domain.trainer.entity.Trainer;
-import BodyBuddy.demo.domain.trainer.repository.TrainerRepository;
 import BodyBuddy.demo.global.common.commonEnum.AuthenticationRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +26,7 @@ public class TrainerService {
                 .orElseThrow(() -> new IllegalArgumentException("트레이너를 찾을 수 없습니다."));
         return trainerConverter.convertToTrainerResponse(trainer);
     }
+
 	/**
 	 * 트레이너 마이페이지 정보 조회
 	 */

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
@@ -33,9 +33,19 @@ public enum SuccessStatus implements BaseCode {
 
 	//트레이너 관련 응답
 	TRAINERS_BY_GYM_SUCCESS(HttpStatus.OK, "TRAINER200", "트레이너 조회 성공입니다."),
+	TRAINER_INFO_SUCCESS(HttpStatus.OK, "TRAINER201", "트레이너 페이지 조회 성공입니다."),
 
 	//지역 관련 응답
 	REGIONSUCCESS(HttpStatus.OK, "REGION200", "지역 조회 성공입니다."),
+
+	//뱃지 관련 응답
+	BADGE_SUCCESS(HttpStatus.OK, "BADGE200", "뱃지 조회 성공입니다."),
+
+	//포트폴리오 관련 응답
+	PORTFOLIO_CREATED(HttpStatus.OK, "PORTFOLIO200", "포트폴리오 등록 성공입니다. "),
+	PORTFOLIO_UPDATED(HttpStatus.OK, "PORTFOLIO201", "포트폴리오 업데이트 성공입니다. "),
+	PORTFOLIO_FETCHED(HttpStatus.OK, "PORTFOLIO202", "포트폴리오 조회 성공입니다.")
+
 	;
 
 

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
@@ -18,10 +18,10 @@ public enum SuccessStatus implements BaseCode {
 	LOGIN_SUCCESS(HttpStatus.OK, "AUTH2000", "로그인 성공입니다."),
 
 	// 회원가입 관련 응답
-	SIGNUP_SUCCESS(HttpStatus.OK,"AUTH2010", "회원가입 성공입니다."),
+	SIGNUP_SUCCESS(HttpStatus.OK, "AUTH2010", "회원가입 성공입니다."),
 
 	// 회원 탈퇴 관련 응답
-	DELETE_ACCOUNT_SUCCESS(HttpStatus.OK,"AUTH2020", "회원 탈퇴 성공입니다."),
+	DELETE_ACCOUNT_SUCCESS(HttpStatus.OK, "AUTH2020", "회원 탈퇴 성공입니다."),
 
 	// 랭킹 관련 응답
 	RANKINGSUCCESS(HttpStatus.OK, "RANKING2000", "랭킹 조회 성공입니다."),
@@ -31,8 +31,12 @@ public enum SuccessStatus implements BaseCode {
 	//헬스장 관련 응답
 	GYMSUCCESS(HttpStatus.OK, "GYM200", "체육관 조회 성공입니다."),
 
+	//트레이너 관련 응답
+	TRAINERS_BY_GYM_SUCCESS(HttpStatus.OK, "TRAINER200", "트레이너 조회 성공입니다."),
+
 	//지역 관련 응답
-	REGIONSUCCESS(HttpStatus.OK, "REGION200", "지역 조회 성공입니다.");
+	REGIONSUCCESS(HttpStatus.OK, "REGION200", "지역 조회 성공입니다."),
+	;
 
 
 	private final HttpStatus httpStatus;
@@ -42,20 +46,20 @@ public enum SuccessStatus implements BaseCode {
 	@Override
 	public ReasonDTO getReason() {
 		return ReasonDTO.builder()
-			.message(message)
-			.code(code)
-			.isSuccess(true)
-			.build();
+				.message(message)
+				.code(code)
+				.isSuccess(true)
+				.build();
 	}
 
 	@Override
 	public ReasonDTO getReasonHttpStatus() {
 		return ReasonDTO.builder()
-			.message(message)
-			.code(code)
-			.isSuccess(true)
-			.httpStatus(httpStatus)
-			.build()
-			;
+				.message(message)
+				.code(code)
+				.isSuccess(true)
+				.httpStatus(httpStatus)
+				.build()
+				;
 	}
 }


### PR DESCRIPTION
## **📌 Summary**
>트레이너 정보 조회 페이지 및 뱃지, 포트폴리오(약력) 기능을 구현하여 트레이너의 프로필을 상세하게 확인할 수 있도록 하였습니다.
---

## **🔍 Related Issues**
>관련된 이슈 번호를 연결하세요. (없다면 "해당 없음" 작성)
  - #35 , #44 

---

## **🚀 Implementation Details**
>주요 변경 사항 및 구현 내용을 자세히 설명하세요.
### 1. 트레이너 정보 조회 API 구현
특정 트레이너의 상세 정보를 조회하는 API를 개발하였습니다.
조회 가능한 정보:
트레이너 기본 정보 (이름, 나이, 키, 몸무게, 소속 체육관 등)
뱃지 리스트
포트폴리오(약력) 리스트
트레이너가 관리하는 회원 리스트
### 2. 트레이너의 뱃지 조회 API 구현
트레이너가 획득한 뱃지 목록을 반환하는 API 개발
뱃지 목록에는 아래와 같은 정보 포함:
뱃지 이름
뱃지 설명
뱃지 아이콘 URL
### 3. 포트폴리오(약력) 관리 기능 구현
포트폴리오 등록 API
트레이너가 자신의 포트폴리오(약력)를 등록할 수 있도록 구현
포트폴리오 수정 API
트레이너가 기존 포트폴리오를 수정할 수 있도록 구현

---
## **💡 Notes**
>이 PR에 대한 추가적인 주석이나 팀원이 참고해야 할 사항을 기록하세요.
  - 모든 API 전부 테스트해보았고 아직 알림은 구현이 안되어서 차차 완성해나가겠습니다.
  - 공통 예외처리 등의 응답처리는 리팩토링에서 수정하겠습니다.
