### PR TITLE
[FEAT] 로그인 리프레시 토큰 구현

### DIFF
--- a/demo/src/main/java/BodyBuddy/demo/domain/member/controller/AuthController.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/controller/AuthController.java
@@ -1,12 +1,17 @@
 package BodyBuddy.demo.domain.member.controller;
 
 import BodyBuddy.demo.domain.member.dto.SignUpRequestDto;
+import BodyBuddy.demo.domain.member.entity.Member;
+import BodyBuddy.demo.domain.member.repository.MemberRepository;
 import BodyBuddy.demo.domain.member.service.MemberService;
 import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.error.MemberErrorCode;
 import BodyBuddy.demo.global.apiPayload.code.status.SuccessStatus;
+import BodyBuddy.demo.global.apiPayload.exception.BodyBuddyException;
+import BodyBuddy.demo.global.jwt.JwtTokenProvider;
+import BodyBuddy.demo.global.service.JwtTokenService;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -22,7 +27,8 @@ public class AuthController {
      * 일반 회원 회원가입
      */
     @PostMapping("/members/signup")
-    public ApiResponse<Void> signupMember(@Valid @RequestBody SignUpRequestDto.MemberSignupRequest request) {
+    public ApiResponse<Void> signupMember(
+        @Valid @RequestBody SignUpRequestDto.MemberSignupRequest request) {
         memberService.signupMember(request);
         return ApiResponse.of(SuccessStatus.SIGNUP_SUCCESS, null);
     }
@@ -31,7 +37,8 @@ public class AuthController {
      * 트레이너 회원가입
      */
     @PostMapping("/trainers/signup")
-    public ApiResponse<Void> signupTrainer(@Valid @RequestBody SignUpRequestDto.TrainerSignupRequest request) {
+    public ApiResponse<Void> signupTrainer(
+        @Valid @RequestBody SignUpRequestDto.TrainerSignupRequest request) {
         memberService.signupTrainer(request);
         return ApiResponse.of(SuccessStatus.SIGNUP_SUCCESS, null);
     }
@@ -40,9 +47,10 @@ public class AuthController {
      * 로그인
      */
     @PostMapping("/login")
-    public ApiResponse<String> login(@Valid @RequestBody SignUpRequestDto.MemberLoginRequest request) {
-        String token = memberService.login(request);
-        return ApiResponse.of(SuccessStatus.LOGIN_SUCCESS, token);
+    public ApiResponse<Map<String, String>> login(
+        @Valid @RequestBody SignUpRequestDto.MemberLoginRequest request) {
+        Map<String, String> tokens = memberService.login(request);
+        return ApiResponse.of(SuccessStatus.LOGIN_SUCCESS, tokens);
     }
 
     /**
@@ -52,5 +60,15 @@ public class AuthController {
     public ApiResponse<Void> deleteUser(@RequestParam String loginId) {
         memberService.deleteUser(loginId);
         return ApiResponse.of(SuccessStatus.DELETE_ACCOUNT_SUCCESS, null);
+    }
+
+    /**
+     * 리프레시 토큰을 사용해 새로운 토큰 재발급
+     */
+    @PostMapping("/refresh")
+    public ApiResponse<SignUpRequestDto.JwtTokenResponse> refreshToken(
+        @RequestBody @Valid SignUpRequestDto.JwtTokenRequest request) {
+        SignUpRequestDto.JwtTokenResponse tokens = memberService.refreshTokens(request.getRefreshToken());
+        return ApiResponse.of(SuccessStatus.TOKEN_REFRESH_SUCCESS, tokens);
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/dto/SignUpRequestDto.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/dto/SignUpRequestDto.java
@@ -128,4 +128,21 @@ public class SignUpRequestDto {
         @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
         private final String password;
     }
+
+    @Getter
+    @NoArgsConstructor(force = true)
+    @AllArgsConstructor
+    @Builder
+    public static class JwtTokenRequest {
+        @NotBlank(message = "RefreshToken은 필수 입력 항목입니다.")
+        private final String refreshToken;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class JwtTokenResponse {
+        private final String accessToken;
+        private final String refreshToken;
+    }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/entity/Member.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/entity/Member.java
@@ -35,13 +35,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 @Entity
 @Table(name = "Member")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -96,6 +98,9 @@ public class Member {
 	@JoinColumn(name = "trainer_id")
 	private Trainer trainer;
 
+	@Column(name = "refresh_token")
+	private String refreshToken;
+
 
 	@JsonIgnore
 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -121,8 +126,4 @@ public class Member {
 
 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<TrainerCalendar> trainerCalendars = new ArrayList<>();
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/repository/MemberRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/repository/MemberRepository.java
@@ -6,13 +6,26 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Member> findByLoginId(String loginId);
+
     boolean existsByLoginId(String loginId);
-    boolean existsByNickname(String nickname); // 닉네임 중복 검사
+
+    boolean existsByNickname(String nickname);
+
     Optional<Member> findById(Long id);
+
     int countByTrainerId(Long trainerId);
+
     List<Member> findByTrainerId(Long trainerId);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.refreshToken = :refreshToken WHERE m.loginId = :loginId")
+    void updateRefreshToken(@Param("loginId") String loginId, @Param("refreshToken") String refreshToken);
 }
 

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/service/MemberService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/service/MemberService.java
@@ -94,7 +94,6 @@ public class MemberService {
      */
     public Map<String, String> login(SignUpRequestDto.MemberLoginRequest request) {
         Member member = memberRepository.findByLoginId(request.getLoginId()).orElse(null);
-        Trainer trainer = trainerRepository.findByLoginId(request.getLoginId()).orElse(null);
 
         if (member != null) {
             if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
@@ -102,6 +101,8 @@ public class MemberService {
             }
             return jwtTokenService.generateTokens(member.getLoginId(), "ROLE_MEMBER");
         }
+
+        Trainer trainer = trainerRepository.findByLoginId(request.getLoginId()).orElse(null);
 
         if (trainer != null) {
             if (!passwordEncoder.matches(request.getPassword(), trainer.getPassword())) {

--- a/demo/src/main/java/BodyBuddy/demo/domain/member/service/MemberService.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import BodyBuddy.demo.domain.gym.entity.Gym;
 import BodyBuddy.demo.domain.gym.service.GymService;
 import BodyBuddy.demo.domain.member.converter.MemberConverter;
 import BodyBuddy.demo.domain.member.dto.SignUpRequestDto;
+import BodyBuddy.demo.domain.member.dto.SignUpRequestDto.JwtTokenResponse;
 import BodyBuddy.demo.domain.member.entity.Member;
 import BodyBuddy.demo.domain.member.repository.MemberRepository;
 import BodyBuddy.demo.domain.trainer.entity.Trainer;
@@ -13,6 +14,8 @@ import BodyBuddy.demo.global.apiPayload.code.error.MemberErrorCode;
 import BodyBuddy.demo.global.apiPayload.code.error.TrainerErrorCode;
 import BodyBuddy.demo.global.apiPayload.exception.BodyBuddyException;
 import BodyBuddy.demo.global.jwt.JwtTokenProvider;
+import BodyBuddy.demo.global.service.JwtTokenService;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AvatarService avatarService;
+    private final JwtTokenService jwtTokenService;
 
     /**
      * 일반 회원(Member) 회원가입
@@ -88,30 +92,24 @@ public class MemberService {
     /**
      * 로그인 처리 (일반 회원(Member) 및 트레이너(Trainer) 구분)
      */
-    public String login(SignUpRequestDto.MemberLoginRequest request) {
-        // Member 조회
+    public Map<String, String> login(SignUpRequestDto.MemberLoginRequest request) {
         Member member = memberRepository.findByLoginId(request.getLoginId()).orElse(null);
-
-        // Trainer 조회
         Trainer trainer = trainerRepository.findByLoginId(request.getLoginId()).orElse(null);
 
-        // 일반 회원 로그인 처리
         if (member != null) {
             if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
                 throw new BodyBuddyException(MemberErrorCode.NOT_MATCH_PASSWORD);
             }
-            return jwtTokenProvider.createToken(member.getLoginId(), "ROLE_MEMBER");
+            return jwtTokenService.generateTokens(member.getLoginId(), "ROLE_MEMBER");
         }
 
-        // 트레이너 로그인 처리
         if (trainer != null) {
             if (!passwordEncoder.matches(request.getPassword(), trainer.getPassword())) {
                 throw new BodyBuddyException(MemberErrorCode.NOT_MATCH_PASSWORD);
             }
-            return jwtTokenProvider.createToken(trainer.getLoginId(), "ROLE_TRAINER");
+            return jwtTokenService.generateTokens(trainer.getLoginId(), "ROLE_TRAINER");
         }
 
-        // 사용자 정보가 없을 경우 예외 처리
         throw new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID);
     }
 
@@ -133,6 +131,43 @@ public class MemberService {
                 .orElseThrow(() -> new BodyBuddyException(TrainerErrorCode.TRAINER_NOT_FOUND));
             trainerRepository.delete(trainer);
             return;
+        }
+
+        throw new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID);
+    }
+
+    /**
+     * 리프레시 토큰을 이용한 새로운 토큰 재발급
+     */
+    public SignUpRequestDto.JwtTokenResponse refreshTokens(String refreshToken) {
+        // 1. 리프레시 토큰 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new BodyBuddyException(MemberErrorCode.INVALID_TOKEN);
+        }
+
+        // 2. 토큰에서 사용자 정보 추출
+        String username = jwtTokenProvider.getUsername(refreshToken);
+
+        // 3. Member와 Trainer를 구분하여 리프레시 토큰 비교
+        Member member = memberRepository.findByLoginId(username).orElse(null);
+        Trainer trainer = trainerRepository.findByLoginId(username).orElse(null);
+
+        if (member != null) {
+            if (!refreshToken.equals(member.getRefreshToken())) {
+                throw new BodyBuddyException(MemberErrorCode.INVALID_TOKEN);
+            }
+            // 4. 새로운 토큰 생성 및 매핑
+            Map<String, String> tokens = jwtTokenService.generateAndStoreTokens(username, "ROLE_MEMBER");
+            return new SignUpRequestDto.JwtTokenResponse(tokens.get("accessToken"), tokens.get("refreshToken"));
+        }
+
+        if (trainer != null) {
+            if (!refreshToken.equals(trainer.getRefreshToken())) {
+                throw new BodyBuddyException(MemberErrorCode.INVALID_TOKEN);
+            }
+            // 4. 새로운 토큰 생성 및 매핑
+            Map<String, String> tokens = jwtTokenService.generateAndStoreTokens(username, "ROLE_TRAINER");
+            return new SignUpRequestDto.JwtTokenResponse(tokens.get("accessToken"), tokens.get("refreshToken"));
         }
 
         throw new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID);

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/entity/Trainer.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/entity/Trainer.java
@@ -90,8 +90,15 @@ public class Trainer {
 	@OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Portfolio> portfolios = new ArrayList<>();
 
+	@Column(name = "refresh_token")
+	private String refreshToken;
+
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+	public void setRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
 	}
 
 	@PrePersist

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/repository/TrainerRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/repository/TrainerRepository.java
@@ -1,6 +1,8 @@
 package BodyBuddy.demo.domain.trainer.repository;
 
 import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import BodyBuddy.demo.global.apiPayload.code.error.TrainerErrorCode;
+import BodyBuddy.demo.global.apiPayload.exception.BodyBuddyException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,11 @@ import java.util.Optional;
 public interface TrainerRepository extends JpaRepository<Trainer, Long> {
     Optional<Trainer> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
+
+    default void updateRefreshToken(String loginId, String refreshToken) {
+        Trainer trainer = findByLoginId(loginId)
+            .orElseThrow(() -> new BodyBuddyException(TrainerErrorCode.TRAINER_NOT_FOUND));
+        trainer.setRefreshToken(refreshToken);
+        save(trainer);
+    }
 }

--- a/demo/src/main/java/BodyBuddy/demo/domain/trainer/repository/TrainerRepository.java
+++ b/demo/src/main/java/BodyBuddy/demo/domain/trainer/repository/TrainerRepository.java
@@ -1,20 +1,26 @@
 package BodyBuddy.demo.domain.trainer.repository;
 
 import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import BodyBuddy.demo.global.apiPayload.code.error.MemberErrorCode;
 import BodyBuddy.demo.global.apiPayload.code.error.TrainerErrorCode;
 import BodyBuddy.demo.global.apiPayload.exception.BodyBuddyException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface TrainerRepository extends JpaRepository<Trainer, Long> {
     Optional<Trainer> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
 
+    @Query("UPDATE Trainer t SET t.refreshToken = :refreshToken WHERE t.loginId = :loginId")
+    @Modifying
+    @Transactional
     default void updateRefreshToken(String loginId, String refreshToken) {
         Trainer trainer = findByLoginId(loginId)
-            .orElseThrow(() -> new BodyBuddyException(TrainerErrorCode.TRAINER_NOT_FOUND));
+            .orElseThrow(() -> new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID));
         trainer.setRefreshToken(refreshToken);
-        save(trainer);
     }
 }

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/error/MemberErrorCode.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/error/MemberErrorCode.java
@@ -20,7 +20,8 @@ public enum MemberErrorCode implements ErrorCode {
 	NOT_MATCH_CONFIRMEDPASS(HttpStatus.BAD_REQUEST, "MEMBER_004", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 	NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER_005", "비밀번호가 일치하지 않습니다."),
 	DUPLICATE_ID(HttpStatus.BAD_REQUEST, "MEMBER_006", "이미 사용 중인 ID입니다."),
-	GENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_007", "잘못된 성별입니다.")
+	GENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_007", "잘못된 성별입니다."),
+	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN_402", "유효하지 않은 토큰입니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/ErrorStatus.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/ErrorStatus.java
@@ -1,5 +1,0 @@
-package BodyBuddy.demo.global.apiPayload.code.status;
-
-public class ErrorStatus {
-
-}

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/code/status/SuccessStatus.java
@@ -14,6 +14,9 @@ public enum SuccessStatus implements BaseCode {
 	// 일반적인 응답
 	_OK(HttpStatus.OK, "COMMON200", "성공입니다."),
 
+	// 토큰 관련 응답
+	TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "TOKEN200", "토큰 리프레시 성공입니다."),
+
 	// 로그인 관련 응답
 	LOGIN_SUCCESS(HttpStatus.OK, "AUTH2000", "로그인 성공입니다."),
 

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/BodyBuddyException.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/BodyBuddyException.java
@@ -1,7 +1,5 @@
 package BodyBuddy.demo.global.apiPayload.exception;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,4 +8,9 @@ import lombok.RequiredArgsConstructor;
 public class BodyBuddyException extends RuntimeException {
 
 	private final ErrorCode errorCode;
+
+	public BodyBuddyException(ErrorCode errorCode, String message) {
+		super(message);
+		this.errorCode = errorCode;
+	}
 }

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/ErrorCode.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public interface ErrorCode {
 	HttpStatus getHttpStatus();
 
 	/**
-	 * 에러 코드 반환 (예: MEMBER_001)
+	 * 에러 코드 반환 (예: "MEMBER_001")
 	 */
 	String getCode();
 

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/ErrorStatus.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/ErrorStatus.java
@@ -1,10 +1,42 @@
 package BodyBuddy.demo.global.apiPayload.exception;
 
-import lombok.AllArgsConstructor;
+import BodyBuddy.demo.global.apiPayload.code.BaseErrorCode;
+import BodyBuddy.demo.global.apiPayload.code.ErrorReasonDTO;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
-@AllArgsConstructor
-public enum ErrorStatus {
+@RequiredArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
 
+    // 회원 관련 예외
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "해당 회원을 찾을 수 없습니다."),
+    DUPLICATE_ID(HttpStatus.BAD_REQUEST, "MEMBER_002", "이미 사용 중인 ID입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER_003", "이미 사용 중인 닉네임입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN_401", "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_402", "리프레시 토큰이 만료되었습니다."),
+    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER_004", "비밀번호가 일치하지 않습니다."),
+
+    // 서버 내부 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_500", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+            .httpStatus(httpStatus)
+            .isSuccess(false)
+            .code(code)
+            .message(message)
+            .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return getReason();
+    }
 }

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/ExceptionAdvice.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/ExceptionAdvice.java
@@ -1,5 +1,61 @@
 package BodyBuddy.demo.global.apiPayload.exception;
 
+import BodyBuddy.demo.global.apiPayload.ApiResponse;
+import BodyBuddy.demo.global.apiPayload.code.error.CommonErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리 핸들러
+ */
+@Slf4j
+@RestControllerAdvice
 public class ExceptionAdvice {
 
+    /**
+     * BodyBuddyException 처리
+     */
+    @ExceptionHandler(BodyBuddyException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBodyBuddyException(BodyBuddyException e) {
+        log.error("BodyBuddyException 발생: {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+            .status(e.getErrorCode().getHttpStatus())
+            .body(ApiResponse.onFailure(
+                e.getErrorCode().getCode(),
+                e.getErrorCode().getMessage(),
+                null
+            ));
+    }
+
+    /**
+     * GeneralException 처리
+     */
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
+        log.error("GeneralException 발생: {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+            .status(e.getErrorCode().getHttpStatus())
+            .body(ApiResponse.onFailure(
+                e.getErrorCode().getCode(),
+                e.getErrorCode().getMessage(),
+                null
+            ));
+    }
+
+    /**
+     * 그 외 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected Exception 발생: ", e);
+        return ResponseEntity
+            .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+            .body(ApiResponse.onFailure(
+                CommonErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+                CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+                null
+            ));
+    }
 }

--- a/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/GeneralException.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/apiPayload/exception/GeneralException.java
@@ -1,5 +1,10 @@
 package BodyBuddy.demo.global.apiPayload.exception;
 
-public class GeneralException {
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
+public class GeneralException extends RuntimeException {
+    private final ErrorCode errorCode;
 }

--- a/demo/src/main/java/BodyBuddy/demo/global/service/JwtTokenService.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/service/JwtTokenService.java
@@ -1,0 +1,88 @@
+package BodyBuddy.demo.global.service;
+
+import BodyBuddy.demo.domain.member.entity.Member;
+import BodyBuddy.demo.domain.member.repository.MemberRepository;
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import BodyBuddy.demo.domain.trainer.repository.TrainerRepository;
+import BodyBuddy.demo.global.apiPayload.code.error.MemberErrorCode;
+import BodyBuddy.demo.global.apiPayload.exception.BodyBuddyException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final MemberRepository memberRepository;
+    private final TrainerRepository trainerRepository;
+
+    @Value("${auth.secret-key}")
+    private String secretKey;
+
+    private final long accessValidity = 3600000; // 1시간
+    private final long refreshValidity = 604800000; // 7일
+
+    @Transactional
+    public Map<String, String> generateTokens(String loginId, String role) {
+        String accessToken = createToken(loginId, role, accessValidity);
+        String refreshToken = createToken(loginId, null, refreshValidity);
+
+        memberRepository.updateRefreshToken(loginId, refreshToken);
+        trainerRepository.updateRefreshToken(loginId, refreshToken);
+
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("accessToken", accessToken);
+        tokens.put("refreshToken", refreshToken);
+        return tokens;
+    }
+
+    @Transactional
+    public Map<String, String> generateAndStoreTokens(String loginId, String role) {
+        String accessToken = createToken(loginId, role, accessValidity);
+        String refreshToken = createToken(loginId, null, refreshValidity);
+
+        Member member = memberRepository.findByLoginId(loginId).orElse(null);
+        Trainer trainer = trainerRepository.findByLoginId(loginId).orElse(null);
+
+        if (member != null) {
+            member.setRefreshToken(refreshToken);
+            memberRepository.save(member);
+        } else if (trainer != null) {
+            trainer.setRefreshToken(refreshToken);
+            trainerRepository.save(trainer);
+        } else {
+            throw new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID);
+        }
+
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("accessToken", accessToken);
+        tokens.put("refreshToken", refreshToken);
+        return tokens;
+    }
+
+    private String createToken(String username, String role, long validity) {
+        Claims claims = Jwts.claims().setSubject(username);
+        if (role != null) {
+            claims.put("role", role);
+        }
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + validity);
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(expiryDate)
+            .signWith(SignatureAlgorithm.HS256, secretKey)
+            .compact();
+    }
+}

--- a/demo/src/main/java/BodyBuddy/demo/global/service/JwtTokenService.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/service/JwtTokenService.java
@@ -36,8 +36,17 @@ public class JwtTokenService {
         String accessToken = createToken(loginId, role, accessValidity);
         String refreshToken = createToken(loginId, null, refreshValidity);
 
-        memberRepository.updateRefreshToken(loginId, refreshToken);
-        trainerRepository.updateRefreshToken(loginId, refreshToken);
+        if ("ROLE_MEMBER".equals(role)) {
+            Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID));
+            member.setRefreshToken(refreshToken);
+            memberRepository.save(member);
+        } else if ("ROLE_TRAINER".equals(role)) {
+            Trainer trainer = trainerRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID));
+            trainer.setRefreshToken(refreshToken);
+            trainerRepository.save(trainer);
+        }
 
         Map<String, String> tokens = new HashMap<>();
         tokens.put("accessToken", accessToken);
@@ -50,17 +59,16 @@ public class JwtTokenService {
         String accessToken = createToken(loginId, role, accessValidity);
         String refreshToken = createToken(loginId, null, refreshValidity);
 
-        Member member = memberRepository.findByLoginId(loginId).orElse(null);
-        Trainer trainer = trainerRepository.findByLoginId(loginId).orElse(null);
-
-        if (member != null) {
-            member.setRefreshToken(refreshToken);
-            memberRepository.save(member);
-        } else if (trainer != null) {
+        if ("ROLE_TRAINER".equals(role)) {
+            Trainer trainer = trainerRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID));
             trainer.setRefreshToken(refreshToken);
             trainerRepository.save(trainer);
-        } else {
-            throw new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID);
+        } else if ("ROLE_MEMBER".equals(role)) {
+            Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID));
+            member.setRefreshToken(refreshToken);
+            memberRepository.save(member);
         }
 
         Map<String, String> tokens = new HashMap<>();

--- a/demo/src/main/java/BodyBuddy/demo/global/util/AuthenticatedUserUtil.java
+++ b/demo/src/main/java/BodyBuddy/demo/global/util/AuthenticatedUserUtil.java
@@ -1,0 +1,70 @@
+package BodyBuddy.demo.global.util;
+
+import BodyBuddy.demo.domain.member.entity.Member;
+import BodyBuddy.demo.domain.member.repository.MemberRepository;
+import BodyBuddy.demo.domain.trainer.entity.Trainer;
+import BodyBuddy.demo.domain.trainer.repository.TrainerRepository;
+import BodyBuddy.demo.global.apiPayload.code.error.CommonErrorCode;
+import BodyBuddy.demo.global.apiPayload.exception.BodyBuddyException;
+import BodyBuddy.demo.global.apiPayload.code.error.MemberErrorCode;
+import BodyBuddy.demo.global.apiPayload.code.error.TrainerErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserUtil {
+
+    private final MemberRepository memberRepository;
+    private final TrainerRepository trainerRepository;
+
+    /**
+     * 현재 로그인한 사용자의 username(loginId) 반환
+     */
+    public String getCurrentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new BodyBuddyException(CommonErrorCode.UNAUTHORIZED);
+        }
+        return authentication.getName(); // username (loginId)
+    }
+
+    /**
+     * 현재 로그인한 사용자가 Member인지 Trainer인지 확인 후 반환
+     */
+    public Object getCurrentUser() {
+        String username = getCurrentUsername();
+
+        Member member = memberRepository.findByLoginId(username).orElse(null);
+        if (member != null) {
+            return member;
+        }
+
+        Trainer trainer = trainerRepository.findByLoginId(username).orElse(null);
+        if (trainer != null) {
+            return trainer;
+        }
+
+        throw new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID);
+    }
+
+    /**
+     * 현재 로그인한 사용자가 Member라면 Member 반환
+     */
+    public Member getCurrentMember() {
+        String username = getCurrentUsername();
+        return memberRepository.findByLoginId(username)
+            .orElseThrow(() -> new BodyBuddyException(MemberErrorCode.NOT_FOUND_ID));
+    }
+
+    /**
+     * 현재 로그인한 사용자가 Trainer라면 Trainer 반환
+     */
+    public Trainer getCurrentTrainer() {
+        String username = getCurrentUsername();
+        return trainerRepository.findByLoginId(username)
+            .orElseThrow(() -> new BodyBuddyException(TrainerErrorCode.TRAINER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## **📌 Summary**
> 로그인 리프레시 토큰 구현 및 예외처리 메시지 반환하도록 내부 로직 구현
---

## **🔍 Related Issues**
>관련된 이슈 번호를 연결하세요. (없다면 "해당 없음" 작성)
  - #53 

---

## **🚀 Implementation Details**
>주요 변경 사항 및 구현 내용을 자세히 설명하세요.
- 기존의 로그인했을 경우에 Access Token 만 발급되던 방식을 Refresh Token을 추가해서 /login api에서 access/refresh token을 반환 받을 수 있고 이 반환 받은 access token을 request header에 넣은 상태로 /refresh api를 호출하면 access/refresh token이 모두 재발급되도록 구현하여 보안성을 강화시켰습니다.
- 다음으로 예외처리를 저번에 구현했었는데 내부의 반환 로직들을 채워넣지 않아서 api 테스트할때 예외 메시지가 보이지 않던 것을 모두 추가해서 보이도록 수정했습니다.
---

## **💡 Notes**
>이 PR에 대한 추가적인 주석이나 팀원이 참고해야 할 사항을 기록하세요.
- 아마 예외처리에서 ExceptionAdvice와 같은 클래스는 나중에 따로 더 수정해야 할 거 같습니다.
- 그리고 리프레시 토큰이 Redis와 함께 사용하면 궁합이 좋다고 해서 나중에 이 방법도 고려해보면 좋을 거 같습니다.
---
## **🧪TEST**
![다운로드](https://github.com/user-attachments/assets/b7467194-a5de-4ea5-86b0-37c4e1cacbdf)

![다운로드 (1)](https://github.com/user-attachments/assets/a33b7497-63e3-4597-a9ef-377fc51d88f6)

![다운로드 (2)](https://github.com/user-attachments/assets/be568efb-8c0e-476e-a468-5d76aef35cfe)

